### PR TITLE
Fixed different leading zeros in filename in nft.py and metadata.py

### DIFF
--- a/metadata.py
+++ b/metadata.py
@@ -56,7 +56,8 @@ def get_attribute_metadata(metadata_path):
     df.columns = [clean_attributes(col) for col in df.columns]
 
     # Get zfill count based on number of images generated
-    zfill_count = len(str(df.shape[0]))
+    # -1 according to nft.py. Otherwise not working for 100 NFTs, 1000 NTFs, 10000 NFTs and so on
+    zfill_count = len(str(df.shape[0]-1))
 
     return df, zfill_count
 


### PR DESCRIPTION
Using len(<nrOfNftsGenerated> -1) for determining leading zeros in image file name. 
old:     zfill_count = len(str(df.shape[0]))
new:     zfill_count = len(str(df.shape[0]-1))
According to nft.py. 
nft.py creates the file name for storing each image
metadata.py creates the file name for the image URI to be stored in the json file for each image
Old version not working for the first number with 2, 3, 4, ... digits (10 NFTs, 100 NFTs, 1000 NTFs, ...), because in this cases metadata.py would use one leading zero more than nft.py for the file name generation.